### PR TITLE
"default"アトリビュートを<value>タグに追加

### DIFF
--- a/CM3D2.AddModsSlider.Plugin.cs
+++ b/CM3D2.AddModsSlider.Plugin.cs
@@ -62,6 +62,7 @@ namespace CM3D2.AddModsSlider.Plugin
             public Dictionary<string, Dictionary<string, float>>  fValue        = new Dictionary<string, Dictionary<string, float>>();
             public Dictionary<string, Dictionary<string, float>>  fVmin         = new Dictionary<string, Dictionary<string, float>>();
             public Dictionary<string, Dictionary<string, float>>  fVmax         = new Dictionary<string, Dictionary<string, float>>();
+            public Dictionary<string, Dictionary<string, float>>  fVdefault     = new Dictionary<string, Dictionary<string, float>>();
             public Dictionary<string, Dictionary<string, string>> sVType        = new Dictionary<string, Dictionary<string, string>>();
             public Dictionary<string, Dictionary<string, string>> sLabel        = new Dictionary<string, Dictionary<string, string>>();
             public Dictionary<string, Dictionary<string, string>> sMatchPattern = new Dictionary<string, Dictionary<string, string>>();
@@ -139,6 +140,7 @@ namespace CM3D2.AddModsSlider.Plugin
                     fValue[key]        = new Dictionary<string, float>();
                     fVmin[key]         = new Dictionary<string, float>();
                     fVmax[key]         = new Dictionary<string, float>();
+                    fVdefault[key]     = new Dictionary<string, float>();
                     sVType[key]        = new Dictionary<string, string>();
                     sLabel[key]        = new Dictionary<string, string>();
                     sMatchPattern[key] = new Dictionary<string, string>();
@@ -159,6 +161,7 @@ namespace CM3D2.AddModsSlider.Plugin
                         
                         fVmin[key][prop] = Single.TryParse(((XmlElement)valueNode).GetAttribute("min"), out x) ? x : 0f;
                         fVmax[key][prop] = Single.TryParse(((XmlElement)valueNode).GetAttribute("max"), out x) ? x : 0f;
+                        fVdefault[key][prop] = Single.TryParse(((XmlElement)valueNode).GetAttribute("default"), out x) ? x : 0f;
 
                         sVType[key][prop] = ((XmlElement)valueNode).GetAttribute("type");
                         switch (sVType[key][prop])
@@ -571,7 +574,7 @@ namespace CM3D2.AddModsSlider.Plugin
                 if (mp.IsNotBoolKey.Contains(key)) // name=keyにBool以外数値が入ってるmod用
                 {
                     float f = ExSaveData.GetFloat(maid, "CM3D2.MaidVoicePitch", key, float.NaN);
-                    if (float.IsNaN(f)) f = 0f;
+                    if (float.IsNaN(f)) f = mp.fVdefault[key][key + ".value"];
 
                     mp.fValue[key][key + ".value"] = f;
                 }
@@ -587,7 +590,7 @@ namespace CM3D2.AddModsSlider.Plugin
 
                             float f = ExSaveData.GetFloat(maid, "CM3D2.MaidVoicePitch", mp.sPropName[key][j], float.NaN);
                             if (!float.IsNaN(f)) mp.fValue[key][prop] = f;
-                            else                 mp.fValue[key][prop] = 0f;
+                            else mp.fValue[key][prop] = mp.fVdefault[key][prop];
                         }
                     }
                 }

--- a/UnityInjector/Config/ModsParam.xml
+++ b/UnityInjector/Config/ModsParam.xml
@@ -14,6 +14,7 @@
     <!ATTLIST value prop_name     CDATA #REQUIRED
                     min           CDATA "0"
                     max           CDATA "10"
+                    default       CDATA "0"
                     label         CDATA ""
                     type          CDATA "num"
                     match_pattern CDATA "([-+]?[0-9]*\.?[0-9]+)">
@@ -32,12 +33,13 @@
         <value prop_name="EYEBALL.width" : 必須。valueの識別名。拡張セーブデータを参照。
                min="0.1"                 : 省略可。規定値は"0"。スライダーの最小値。
                max="2.0"                 : 省略可。規定値は"10"。スライダーの最大値。
+               default="1.0"             : 省略可。規定値は"0"。スライダーのデフォルト値。
                label="横"                : 省略可。規定値は空白。スライダーのラベル。
                type="scale"              : 省略可。規定値は"num"。「倍率」なら"scale"。「整数値」なら"int"。
                match_pattern="..."       : 省略可。規定値は"([-+]?[0-9]*\.?[0-9]+)"。valueの正規表現マッチパターン。
          />
 
-        <value prop_name="EYEBALL.height" min="0.1" max="2.0" label="縦" type="scale" />
+        <value prop_name="EYEBALL.height" min="0.1" max="2.0" default="1.0" label="縦" type="scale" />
                                           : <value ... /> の一行表記。
 
         ...                               : modが必要とする入力数値分だけ、 <value ... /> を記載する。
@@ -59,90 +61,90 @@
     <mod id="FACEBLEND_OFF" description ="@FaceBlendによる表情変化抑制" type="toggle" />
 
     <mod id="EYETOCAM" description ="目をカメラに向ける">
-        <value prop_name="EYETOCAM.value" min="-1" max="1" label="数値" type="int" />
+        <value prop_name="EYETOCAM.value" min="-1" max="1" default="0" label="数値" type="int" />
     </mod>
     
     <mod id="HEADTOCAM" description ="顔をカメラに向ける">
-        <value prop_name="HEADTOCAM.value" min="-1" max="1" label="数値" type="int" />
+        <value prop_name="HEADTOCAM.value" min="-1" max="1" default="0" label="数値" type="int" />
     </mod>
 
     <mod id="PITCH" description ="声のピッチ">
-        <value prop_name="PITCH.value" min="-1" max="1" label="数値" type="num" />
+        <value prop_name="PITCH.value" min="-1" max="1" default="1.0" label="数値" type="num" />
     </mod>
 
     <mod id="MABATAKI" description ="目の開度">
-        <value prop_name="MABATAKI.value" min="0" max="1.0" label="数値" type="num" />
+        <value prop_name="MABATAKI.value" min="0" max="1.0" default="1.0" label="数値" type="num" />
     </mod>
 
     <mod id="FACE_ANIME_SPEED" description="表情変化速度(1.0で標準)">
-        <value prop_name="FACE_ANIME_SPEED.value" min="0" max="2" label="数値" type="num" />
+        <value prop_name="FACE_ANIME_SPEED.value" min="0" max="2" default="1.0" label="数値" type="num" />
     </mod>
 
     <mod id="EYEBALL" description="瞳の大きさ">
-        <value prop_name="EYEBALL.width" min="0.1" max="2.0" label="横" type="scale" />
-        <value prop_name="EYEBALL.height" min="0.1" max="2.0" label="縦" type="scale" />
+        <value prop_name="EYEBALL.width" min="0.1" max="2.0" default="1.0" label="横" type="scale" />
+        <value prop_name="EYEBALL.height" min="0.1" max="2.0" default="1.0" label="縦" type="scale" />
     </mod>
 
     <mod id="EYE_RATIO" description="目の縦横比率">
-        <value prop_name="EYE_RATIO.value" min="0.1" max="2.0" label="比率" type="scale" />
+        <value prop_name="EYE_RATIO.value" min="0.1" max="2.0" default="1.0" label="比率" type="scale" />
     </mod>
 
     <mod id="EYE_ANG" description="目の角度">
-        <value prop_name="EYE_ANG.angle" min="-60" max="60" label="角度"  type="num" />
-        <value prop_name="EYE_ANG.x" min="-200" max="200" label="縦補正"  type="num" />
-        <value prop_name="EYE_ANG.y" min="-200" max="200" label="横補正"  type="num" />
+        <value prop_name="EYE_ANG.angle" min="-60" max="60" default="0" label="角度"  type="num" />
+        <value prop_name="EYE_ANG.x" min="-200" max="200" default="0" label="縦補正"  type="num" />
+        <value prop_name="EYE_ANG.y" min="-200" max="200" default="0" label="横補正"  type="num" />
     </mod>
 
     <mod id="PELSCL" description="骨盤スケーリング">
-        <value prop_name="PELSCL.width" min="0.1" max="2.0" label="横幅" type="scale" />
-        <value prop_name="PELSCL.depth" min="0.1" max="2.0" label="奥行" type="scale" />
-        <value prop_name="PELSCL.height" min="0.1" max="2.0" label="高さ" type="scale" />
+        <value prop_name="PELSCL.width" min="0.1" max="2.0" default="1.0" label="横幅" type="scale" />
+        <value prop_name="PELSCL.depth" min="0.1" max="2.0" default="1.0" label="奥行" type="scale" />
+        <value prop_name="PELSCL.height" min="0.1" max="2.0" default="1.0" label="高さ" type="scale" />
     </mod>
 
     <mod id="SKTSCL" description="スカート周辺スケーリング">
-        <value prop_name="SKTSCL.width"  min="0.1" max="3.0" label="横幅" type="num" />
-        <value prop_name="SKTSCL.depth"  min="0.1" max="3.0" label="奥行" type="num" />
-        <value prop_name="SKTSCL.height" min="0.1" max="3.0" label="高さ" type="num" />
+        <value prop_name="SKTSCL.width"  min="0.1" max="3.0" default="1.0" label="横幅" type="num" />
+        <value prop_name="SKTSCL.depth"  min="0.1" max="3.0" default="1.0" label="奥行" type="num" />
+        <value prop_name="SKTSCL.height" min="0.1" max="3.0" default="1.0" label="高さ" type="num" />
     </mod>
 
     <mod id="PELVIS" description="骨盤部コリジョン指定">
-        <value prop_name="PELVIS.x" min="-2.0" max="10.0" label="数値1" type="num" />
-        <value prop_name="PELVIS.y" min="-2.0" max="10.0" label="数値2" type="num" />
-        <value prop_name="PELVIS.z" min="-2.0" max="10.0" label="数値3" type="num" />
+        <value prop_name="PELVIS.x" min="-2.0" max="10.0" default="1.0" label="数値1" type="num" />
+        <value prop_name="PELVIS.y" min="-2.0" max="10.0" default="1.0" label="数値2" type="num" />
+        <value prop_name="PELVIS.z" min="-2.0" max="10.0" default="1.0" label="数値3" type="num" />
     </mod>
 
     <mod id="THISCL" description="足全体のスケーリング">
-        <value prop_name="THISCL.width" min="0.1" max="2.0" label="横幅" type="scale" />
-        <value prop_name="THISCL.depth" min="0.1" max="2.0" label="奥行" type="scale" />
+        <value prop_name="THISCL.width" min="0.1" max="2.0" default="1.0" label="横幅" type="scale" />
+        <value prop_name="THISCL.depth" min="0.1" max="2.0" default="1.0" label="奥行" type="scale" />
     </mod>
 
     <mod id="THIPOS" description="足の位置">
-        <value prop_name="THIPOS.x" min="-100" max="200" label="左右" type="num" />
-        <value prop_name="THIPOS.z" min="-100" max="200" label="前後" type="num" />
+        <value prop_name="THIPOS.x" min="-100" max="200" default="1.0" label="左右" type="num" />
+        <value prop_name="THIPOS.z" min="-100" max="200" default="1.0" label="前後" type="num" />
     </mod>
 
     <mod id="SPISCL" description="胴(下腹部)スケーリング">
-        <value prop_name="SPISCL.width"  min="0.1" max="3.0" label="横幅" type="num" />
-        <value prop_name="SPISCL.depth"  min="0.1" max="3.0" label="奥行" type="num" />
-        <value prop_name="SPISCL.height" min="0.1" max="3.0" label="高さ" type="num" />
+        <value prop_name="SPISCL.width"  min="0.1" max="3.0" default="1.0" label="横幅" type="num" />
+        <value prop_name="SPISCL.depth"  min="0.1" max="3.0" default="1.0" label="奥行" type="num" />
+        <value prop_name="SPISCL.height" min="0.1" max="3.0" default="1.0" label="高さ" type="num" />
     </mod>
 
     <mod id="S0ASCL" description="胴(腹部)スケーリング">
-        <value prop_name="S0ASCL.width"  min="0.1" max="3.0" label="横幅" type="num" />
-        <value prop_name="S0ASCL.depth"  min="0.1" max="3.0" label="奥行" type="num" />
-        <value prop_name="S0ASCL.height" min="0.1" max="3.0" label="高さ" type="num" />
+        <value prop_name="S0ASCL.width"  min="0.1" max="3.0" default="1.0" label="横幅" type="num" />
+        <value prop_name="S0ASCL.depth"  min="0.1" max="3.0" default="1.0" label="奥行" type="num" />
+        <value prop_name="S0ASCL.height" min="0.1" max="3.0" default="1.0" label="高さ" type="num" />
     </mod>
 
     <mod id="S1_SCL" description="胴(みぞおち)スケーリング">
-        <value prop_name="S1_SCL.width"  min="0.1" max="3.0" label="横幅" type="num" />
-        <value prop_name="S1_SCL.depth"  min="0.1" max="3.0" label="奥行" type="num" />
-        <value prop_name="S1_SCL.height" min="0.1" max="3.0" label="高さ" type="num" />
+        <value prop_name="S1_SCL.width"  min="0.1" max="3.0" default="1.0" label="横幅" type="num" />
+        <value prop_name="S1_SCL.depth"  min="0.1" max="3.0" default="1.0" label="奥行" type="num" />
+        <value prop_name="S1_SCL.height" min="0.1" max="3.0" default="1.0" label="高さ" type="num" />
     </mod>
 
     <mod id="S1ASCL" description="胴(肋骨)スケーリング">
-        <value prop_name="S1ASCL.width"  min="0.1" max="3.0" label="横幅" type="num" />
-        <value prop_name="S1ASCL.depth"  min="0.1" max="3.0" label="奥行" type="num" />
-        <value prop_name="S1ASCL.height" min="0.1" max="3.0" label="高さ" type="num" />
+        <value prop_name="S1ASCL.width"  min="0.1" max="3.0" default="1.0" label="横幅" type="num" />
+        <value prop_name="S1ASCL.depth"  min="0.1" max="3.0" default="1.0" label="奥行" type="num" />
+        <value prop_name="S1ASCL.height" min="0.1" max="3.0" default="1.0" label="高さ" type="num" />
     </mod>
 
 


### PR DESCRIPTION
とりあえずmaster宛てにしていますが、問題があれば再ポストします

その３>>41, >>57を実装したものです。`<value>`タグに`default`属性が追加され、以下のような記述になります

``` XML
<mod id="SKTSCL" description="スカート周辺スケーリング">
    <value prop_name="SKTSCL.width"  min="0.1" max="3.0" default="1.0" label="横幅" type="num" />
    <value prop_name="SKTSCL.depth"  min="0.1" max="3.0" default="1.0" label="奥行" type="num" />
    <value prop_name="SKTSCL.height" min="0.1" max="3.0" default="1.0" label="高さ" type="num" />
</mod>
```

コードの変更点は以下の通りです
- ModsParam.xml
  - "default"属性を追加
- ModsParam.fVdefaultを追加し、float.IsNaN時のデフォルト値としてこの値を使うように変更
