### PR TITLE
MaidVoicePitchへの更新通知処理を追加

### DIFF
--- a/CM3D2.AddModsSlider.Plugin.cs
+++ b/CM3D2.AddModsSlider.Plugin.cs
@@ -29,6 +29,7 @@ namespace CM3D2.AddModsSlider.Plugin
         private float fLastInitTime      = 0f;
         private ModsParam mp;
         private Maid maid;
+        private GameObject goMaidVoicePitch;
 
         GameObject goAMSPanel;
         GameObject goScrollView;
@@ -214,6 +215,7 @@ namespace CM3D2.AddModsSlider.Plugin
             {
                 initCompleted = false;
                 xmlLoad = mp.Init();
+                goMaidVoicePitch = GameObject.Find("MaidVoicePitch");
             }
         }
 
@@ -263,6 +265,11 @@ namespace CM3D2.AddModsSlider.Plugin
             mp.fValue[key][prop] = value;
 
             setExSaveData(key, prop);
+
+            if (goMaidVoicePitch != null)
+            {
+                goMaidVoicePitch.SendMessage("UpdateSliders");
+            }
         }
 
     //--------


### PR DESCRIPTION
コールバックを追加してみたのですが、考えてみるとAddModsSlider側で既にコールバック処理はしているので、乗っけさせてもらったほうが変更等にも強くシンプルで良いかな、という提案です。

[MaidVoicePitch.UpdateSliders](https://github.com/neguse11/cm3d2_plugins_okiba/blob/40f8417397c53ec69a9a3ae686169bed5305b3d7/MaidVoicePitch/MaidVoicePitchPlugin.cs#L208)というメソッドを追加したので、このパッチはこれを呼んでもらうように変更します。バージョンが違う等で呼び先がない場合も正常に動作します。
